### PR TITLE
fix: validate userid against authenticated user in load.php (issue #4)

### DIFF
--- a/instances/load.php
+++ b/instances/load.php
@@ -38,6 +38,10 @@ $userid  = optional_param('usr', 0, PARAM_INT);
 
 require_login($course, true, $cm);
 
+if ($userid !== (int)$USER->id) {
+    throw new moodle_exception('accessdenied', 'admin');
+}
+
 $PAGE->set_url('/mod/guacamole/start.php');
 
 $user = $DB->get_record('user', ['id' => $userid]);


### PR DESCRIPTION
## Summary

- Añade validación en `instances/load.php` para que el parámetro `usr` de la URL coincida con el usuario autenticado
- Sin esta comprobación, cualquier usuario podría pasar `usr=otro_id` y crear/iniciar VMs en nombre de otro usuario

## Cambio

```php
if ($userid !== (int)$USER->id) {
    throw new moodle_exception('accessdenied', 'admin');
}
```

## Test plan
- [x] 0 errores PHPCS
- [x] CI verde

Closes #4