### PR TITLE
fix: get_instance() uses its $id parameter instead of hardcoded 3 (issue #7)

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -141,8 +141,8 @@ function guacamole_remove_instance_in_use($guacamole) {
  * @return stdClass|false The record, or false if not found.
  */
 function get_instance($id) {
-    $guacamole = $DB->get_record('guacamole', ['id' => '3']);
-    return $guacamole;
+    global $DB;
+    return $DB->get_record('guacamole', ['id' => $id]);
 }
 
 /**


### PR DESCRIPTION
## Summary

Corrige `get_instance()` en `lib.php` que ignoraba su parámetro `$id` y siempre buscaba el registro con `id=3` (valor hardcodeado de desarrollo).

Closes #7