### PR TITLE
fix: cron_task crash when activeConnections returns null/object

### DIFF
--- a/classes/task/cron_task.php
+++ b/classes/task/cron_task.php
@@ -51,32 +51,12 @@ class cron_task extends \core\task\scheduled_task {
     public function execute() {
         global $CFG, $DB;
 
-        $ch = curl_init($CFG->guacamole_domain . "/guacamole/api/tokens");
-        $nombredeusuario = $CFG->guacamole_user;
-        $parametros = 'username=' . $nombredeusuario . '&password=' . $CFG->guacamole_password;
-        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, 'username=' . $nombredeusuario . '&password=' . $CFG->guacamole_password);
+        $token = guacamole_get_token();
+        $activeconnections = guacamole_api_request($token, '/guacamole/api/session/data/mysql/activeConnections');
 
-        $res = curl_exec($ch);
-        $var = json_decode($res, true);
-        curl_close($ch);
-
-        $tokens = $var['authToken'];
-
-        $ch = curl_init($CFG->guacamole_domain . "/guacamole/api/session/data/mysql/activeConnections?token=" . $tokens);
-
-        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-
-        $res = curl_exec($ch);
-        curl_close($ch);
-
-        $var = json_decode($res, true);
-        $users = array_column($var, 'username');
-        $connections = array_column($var, 'connectionIdentifier');
+        // activeConnections returns a JSON object (map), not an array — convert to sequential array.
+        $activeconnections = array_values($activeconnections ?: []);
+        $connections = array_column($activeconnections, 'connectionIdentifier');
 
         $guacamolecomputers = $DB->get_records('guacamole_computers', ['state' => 'started', 'root' => $CFG->wwwroot]);
         foreach ($guacamolecomputers as $guacamolecomputer) {


### PR DESCRIPTION
## Summary
- Sustituye el bloque cURL de 13 líneas por las funciones helper `guacamole_get_token()` y `guacamole_api_request()`
- Añade `array_values($activeconnections ?: [])` porque el endpoint `activeConnections` devuelve un objeto JSON (mapa), no un array secuencial; `array_column()` requiere array secuencial

## Causa del error reportado
```
array_column(): Argument #1 ($array) must be of type array, null given
```
El endpoint devolvía un mapa JSON `{"id1": {...}, "id2": {...}}` y `json_decode(..., true)` devuelve un array asociativo. Si la respuesta era `null` (error de autenticación o red), `array_column()` petaba directamente.

## Test plan
- [ ] Ejecutar la tarea cron manualmente: `php admin/cli/scheduled_task.php --execute=\\mod_guacamole\\task\\cron_task`
- [ ] CI verde en esta PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)